### PR TITLE
test(accounts): add Vitest coverage for store, validation and UI components

### DIFF
--- a/src/components/accounts/AccountRow.spec.ts
+++ b/src/components/accounts/AccountRow.spec.ts
@@ -1,0 +1,60 @@
+import { mount, type VueWrapper } from '@vue/test-utils'
+import { describe, it, expect } from 'vitest'
+import AccountRow from './AccountRow.vue'
+import type { Account, AccountDraft } from '@/types/accounts'
+
+function mountRow(model?: AccountDraft) {
+  return mount(AccountRow, {
+    props: {
+      modelValue: model ?? {
+        id: 'r1',
+        labelsInput: 'HR',
+        type: 'Local',
+        login: 'a',
+        password: 'p',
+        errors: {},
+        touched: {},
+      },
+    },
+    global: { stubs: {} },
+  })
+}
+
+function firstEmitted<T>(w: VueWrapper<unknown>, name: string): T | undefined {
+  const all = w.emitted(name)
+  return all && all[0] ? (all[0][0] as T) : undefined
+}
+
+describe('AccountRow', () => {
+  it('emits submit-valid on blur when valid', async () => {
+    const w = mountRow()
+    const inputs = w.findAll('input')
+    await inputs[0].trigger('blur') // labels
+    await inputs[1].trigger('blur') // login
+    await inputs[2].trigger('blur') // password
+
+    const ev = firstEmitted<Account>(w, 'submit-valid')
+    expect(ev).toBeTruthy()
+    expect(ev!.id).toBe('r1')
+  })
+
+  it('toggle show/hide password changes input type', async () => {
+    const w = mountRow()
+    const pwd = w.find('input[type="password"]')
+    expect(pwd.exists()).toBe(true)
+    const eye = w.find('.eye-btn')
+    await eye.trigger('click')
+    expect(w.find('input[type="text"]').exists()).toBe(true)
+  })
+
+  it('switch to LDAP hides password and clears it', async () => {
+    const w = mountRow()
+    const current = w.props('modelValue') as AccountDraft
+    await w.setProps({
+      modelValue: { ...current, type: 'LDAP', password: '' },
+    })
+    await w.vm.$nextTick()
+    expect(w.find('input[type="password"]').exists()).toBe(false)
+    expect(w.find('input[placeholder="Пароль"]').exists()).toBe(false)
+  })
+})

--- a/src/components/accounts/AccountRow.vue
+++ b/src/components/accounts/AccountRow.vue
@@ -184,10 +184,4 @@ const loginClass = computed(() => (showPassword.value ? 'login' : 'login login--
   align-items: center;
   justify-content: center;
 }
-
-.eye-btn {
-  padding: 0 6px;
-  height: 24px;
-  line-height: 24px;
-}
 </style>

--- a/src/components/accounts/AccountRow.vue
+++ b/src/components/accounts/AccountRow.vue
@@ -3,7 +3,6 @@
     <n-tooltip :disabled="!errMsg('labels')" trigger="hover" placement="top">
       <template #trigger>
         <n-input
-          v-if="!readonly"
           v-model:value="draft.labelsInput"
           placeholder="Метка (через ; )"
           @blur="onBlur('labels')"
@@ -11,17 +10,11 @@
           :title="errMsg('labels') || undefined"
           :aria-invalid="Boolean(err('labels'))"
         />
-        <n-input v-else :value="labelsReadonly" disabled />
       </template>
       {{ errMsg('labels') }}
     </n-tooltip>
 
-    <n-select
-      :options="typeOptions"
-      v-model:value="draft.type"
-      :disabled="readonly"
-      @update:value="onTypeChange"
-    />
+    <n-select :options="typeOptions" v-model:value="draft.type" @update:value="onTypeChange" />
 
     <n-tooltip :disabled="!errMsg('login')" trigger="hover" placement="top">
       <template #trigger>
@@ -29,7 +22,6 @@
           :class="loginClass"
           v-model:value="draft.login"
           placeholder="Логин"
-          :disabled="readonly"
           @blur="onBlur('login')"
           :status="err('login')"
           :title="errMsg('login') || undefined"
@@ -46,7 +38,6 @@
           v-model:value="draft.password"
           type="password"
           placeholder="Пароль"
-          :disabled="readonly"
           @blur="onBlur('password')"
           :status="err('password')"
           :title="errMsg('password') || undefined"
@@ -65,7 +56,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { NInput, NSelect, NButton, NTooltip } from 'naive-ui'
 import type { Account, AccountDraft } from '@/types/accounts'
 import { validateDraft } from '@/composables/useAccountValidation'
@@ -83,18 +74,30 @@ const emit = defineEmits<{
   (e: 'edit'): void
 }>()
 
-const draft = computed({
-  get: () =>
-    props.modelValue ?? {
-      id: props.initial?.id ?? '',
-      labelsInput: props.initial?.labels?.map((t) => t.text).join('; ') ?? '',
-      type: props.initial?.type ?? 'Local',
-      login: props.initial?.login ?? '',
-      password: props.initial?.password ?? '',
-      errors: {},
-      touched: {},
-    },
-  set: (v: AccountDraft) => emit('update:modelValue', v),
+const inner = ref<AccountDraft>({
+  id: props.initial?.id ?? '',
+  labelsInput: props.initial?.labels?.map((t) => t.text).join('; ') ?? '',
+  type: props.initial?.type ?? 'Local',
+  login: props.initial?.login ?? '',
+  password: props.initial?.password ?? '',
+  errors: {},
+  touched: {},
+})
+
+watch(
+  () => props.modelValue,
+  (v) => {
+    if (v) inner.value = v
+  },
+  { immediate: true },
+)
+
+const draft = computed<AccountDraft>({
+  get: () => props.modelValue ?? inner.value,
+  set: (v) => {
+    if (props.modelValue) emit('update:modelValue', v)
+    else inner.value = v
+  },
 })
 
 const typeOptions = [
@@ -102,8 +105,7 @@ const typeOptions = [
   { label: 'Локальная', value: 'Local' },
 ]
 
-const showPassword = computed(() => !props.readonly && draft.value.type === 'Local')
-const labelsReadonly = computed(() => props.initial?.labels.map((t) => t.text).join('; ') ?? '')
+const showPassword = computed(() => draft.value.type === 'Local')
 
 function err(field: 'labels' | 'login' | 'password') {
   return draft.value.touched?.[field] && draft.value.errors?.[field] ? 'error' : undefined

--- a/src/components/accounts/AccountRow.vue
+++ b/src/components/accounts/AccountRow.vue
@@ -36,13 +36,25 @@
         <n-input
           class="password"
           v-model:value="draft.password"
-          type="password"
+          :type="showPwd ? 'text' : 'password'"
           placeholder="Пароль"
           @blur="onBlur('password')"
           :status="err('password')"
           :title="errMsg('password') || undefined"
           :aria-invalid="Boolean(err('password'))"
-        />
+        >
+          <template #suffix>
+            <n-button
+              text
+              class="eye-btn"
+              @mousedown.prevent
+              @click.prevent="togglePwd"
+              :title="showPwd ? 'Скрыть' : 'Показать'"
+            >
+              {{ showPwd ? '🙈' : '👁️' }}
+            </n-button>
+          </template>
+        </n-input>
       </template>
       {{ errMsg('password') }}
     </n-tooltip>
@@ -107,6 +119,12 @@ const typeOptions = [
 
 const showPassword = computed(() => draft.value.type === 'Local')
 
+const showPwd = ref(false)
+
+function togglePwd() {
+  showPwd.value = !showPwd.value
+}
+
 function err(field: 'labels' | 'login' | 'password') {
   return draft.value.touched?.[field] && draft.value.errors?.[field] ? 'error' : undefined
 }
@@ -165,5 +183,11 @@ const loginClass = computed(() => (showPassword.value ? 'login' : 'login login--
   display: inline-flex;
   align-items: center;
   justify-content: center;
+}
+
+.eye-btn {
+  padding: 0 6px;
+  height: 24px;
+  line-height: 24px;
 }
 </style>

--- a/src/components/accounts/AccountRow.vue
+++ b/src/components/accounts/AccountRow.vue
@@ -1,14 +1,21 @@
 <template>
   <div class="row" :class="{ readonly }">
     <!-- Метка -->
-    <n-input
-      v-if="!readonly"
-      v-model:value="draft.labelsInput"
-      placeholder="Метка (через ; )"
-      @blur="onBlur('labels')"
-      :status="err('labels')"
-    />
-    <n-input v-else :value="labelsReadonly" disabled />
+    <n-tooltip :disabled="!errMsg('labels')" trigger="hover" placement="top">
+      <template #trigger>
+        <n-input
+          v-if="!readonly"
+          v-model:value="draft.labelsInput"
+          placeholder="Метка (через ; )"
+          @blur="onBlur('labels')"
+          :status="err('labels')"
+          :title="errMsg('labels') || undefined"
+          :aria-invalid="Boolean(err('labels'))"
+        />
+        <n-input v-else :value="labelsReadonly" disabled />
+      </template>
+      {{ errMsg('labels') }}
+    </n-tooltip>
 
     <!-- Тип записи -->
     <n-select
@@ -19,24 +26,37 @@
     />
 
     <!-- Логин -->
-    <n-input
-      v-model:value="draft.login"
-      placeholder="Логин"
-      :disabled="readonly"
-      @blur="onBlur('login')"
-      :status="err('login')"
-    />
+    <n-tooltip :disabled="!errMsg('login')" trigger="hover" placement="top">
+      <template #trigger>
+        <n-input
+          v-model:value="draft.login"
+          placeholder="Логин"
+          :disabled="readonly"
+          @blur="onBlur('login')"
+          :status="err('login')"
+          :title="errMsg('login') || undefined"
+          :aria-invalid="Boolean(err('login'))"
+        />
+      </template>
+      {{ errMsg('login') }}
+    </n-tooltip>
 
     <!-- Пароль (только Local и не readonly) -->
-    <n-input
-      v-if="showPassword"
-      v-model:value="draft.password"
-      type="password"
-      placeholder="Пароль"
-      :disabled="readonly"
-      @blur="onBlur('password')"
-      :status="err('password')"
-    />
+    <n-tooltip v-if="showPassword" :disabled="!errMsg('password')" trigger="hover" placement="top">
+      <template #trigger>
+        <n-input
+          v-model:value="draft.password"
+          type="password"
+          placeholder="Пароль"
+          :disabled="readonly"
+          @blur="onBlur('password')"
+          :status="err('password')"
+          :title="errMsg('password') || undefined"
+          :aria-invalid="Boolean(err('password'))"
+        />
+      </template>
+      {{ errMsg('password') }}
+    </n-tooltip>
     <n-input v-else-if="!readonly" value="" disabled placeholder="Пароль скрыт для LDAP" />
 
     <!-- Действия -->
@@ -46,7 +66,7 @@
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { NInput, NSelect, NButton } from 'naive-ui'
+import { NInput, NSelect, NButton, NTooltip } from 'naive-ui' // + NTooltip
 import type { Account, AccountDraft } from '@/types/accounts'
 import { validateDraft } from '@/composables/useAccountValidation'
 
@@ -87,6 +107,9 @@ const labelsReadonly = computed(() => props.initial?.labels.map((t) => t.text).j
 
 function err(field: 'labels' | 'login' | 'password') {
   return draft.value.touched?.[field] && draft.value.errors?.[field] ? 'error' : undefined
+}
+function errMsg(field: 'labels' | 'login' | 'password') {
+  return draft.value.touched?.[field] ? draft.value.errors?.[field] || '' : ''
 }
 
 function runValidation() {

--- a/src/components/accounts/AccountRow.vue
+++ b/src/components/accounts/AccountRow.vue
@@ -176,6 +176,12 @@ const loginClass = computed(() => (showPassword.value ? 'login' : 'login login--
   justify-self: end;
 }
 
+.eye-btn {
+  padding: 0 6px;
+  height: 24px;
+  line-height: 24px;
+}
+
 .trash-btn {
   width: 32px;
   height: 32px;

--- a/src/components/accounts/AccountRow.vue
+++ b/src/components/accounts/AccountRow.vue
@@ -1,6 +1,5 @@
 <template>
   <div class="row" :class="{ readonly }">
-    <!-- Метка -->
     <n-tooltip :disabled="!errMsg('labels')" trigger="hover" placement="top">
       <template #trigger>
         <n-input
@@ -17,7 +16,6 @@
       {{ errMsg('labels') }}
     </n-tooltip>
 
-    <!-- Тип записи -->
     <n-select
       :options="typeOptions"
       v-model:value="draft.type"
@@ -25,10 +23,10 @@
       @update:value="onTypeChange"
     />
 
-    <!-- Логин -->
     <n-tooltip :disabled="!errMsg('login')" trigger="hover" placement="top">
       <template #trigger>
         <n-input
+          :class="loginClass"
           v-model:value="draft.login"
           placeholder="Логин"
           :disabled="readonly"
@@ -41,10 +39,10 @@
       {{ errMsg('login') }}
     </n-tooltip>
 
-    <!-- Пароль (только Local и не readonly) -->
     <n-tooltip v-if="showPassword" :disabled="!errMsg('password')" trigger="hover" placement="top">
       <template #trigger>
         <n-input
+          class="password"
           v-model:value="draft.password"
           type="password"
           placeholder="Пароль"
@@ -57,16 +55,18 @@
       </template>
       {{ errMsg('password') }}
     </n-tooltip>
-    <n-input v-else-if="!readonly" value="" disabled placeholder="Пароль скрыт для LDAP" />
 
-    <!-- Действия -->
-    <n-button quaternary @click="$emit('delete')">🗑</n-button>
+    <div class="actions">
+      <n-button quaternary @click="$emit('delete')" class="trash-btn" title="Удалить">
+        🗑
+      </n-button>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { NInput, NSelect, NButton, NTooltip } from 'naive-ui' // + NTooltip
+import { NInput, NSelect, NButton, NTooltip } from 'naive-ui'
 import type { Account, AccountDraft } from '@/types/accounts'
 import { validateDraft } from '@/composables/useAccountValidation'
 
@@ -124,18 +124,44 @@ function onBlur(field: 'labels' | 'login' | 'password') {
 }
 
 function onTypeChange() {
-  // если переключили в LDAP — пароль скрываем и чистим
   if (draft.value.type === 'LDAP') draft.value.password = ''
   draft.value.touched.type = true
   runValidation()
 }
+
+const loginClass = computed(() => (showPassword.value ? 'login' : 'login login--wide'))
 </script>
 
 <style scoped>
 .row {
   display: grid;
-  grid-template-columns: 1.2fr 0.8fr 1fr 1fr auto;
-  gap: 8px;
-  margin-bottom: 8px;
+  grid-template-columns: 1.2fr 0.9fr 1.6fr 1.2fr 40px;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.login {
+  grid-column: 3;
+}
+.password {
+  grid-column: 4;
+}
+.login--wide {
+  grid-column: 3 / 5;
+}
+
+.actions {
+  grid-column: 5;
+  justify-self: end;
+}
+
+.trash-btn {
+  width: 32px;
+  height: 32px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
 }
 </style>

--- a/src/components/accounts/AccountsForm.spec.ts
+++ b/src/components/accounts/AccountsForm.spec.ts
@@ -1,0 +1,37 @@
+import { mount } from '@vue/test-utils'
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import AccountsForm from './AccountsForm.vue'
+import { useAccountsStore } from '@/stores/accounts'
+
+describe('AccountsForm', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+  })
+
+  it('adds new draft to the end', async () => {
+    const w = mount(AccountsForm)
+    const btn = w.get('button')
+    await btn.trigger('click')
+    await btn.trigger('click')
+    const rows = w.findAllComponents({ name: 'AccountRow' })
+    expect(rows.length).toBe(2)
+  })
+
+  it('saves valid row to store and persists', async () => {
+    const w = mount(AccountsForm)
+    const btn = w.get('button')
+    await btn.trigger('click')
+
+    const inputs = w.findAll('input')
+    await inputs[1].setValue('alice')
+    await inputs[2].setValue('pwd')
+    await inputs[1].trigger('blur')
+    await inputs[2].trigger('blur')
+
+    const store = useAccountsStore()
+    expect(store.items.length).toBe(1)
+    expect(JSON.parse(localStorage.getItem('accounts:v1')!)).toHaveLength(1)
+  })
+})

--- a/src/components/accounts/AccountsForm.vue
+++ b/src/components/accounts/AccountsForm.vue
@@ -7,17 +7,6 @@
 
     <p class="hint">Для указания нескольких меток используйте разделитель «;»</p>
 
-    <!-- Сохранённые элементы из стора (показываем как readonly) -->
-    <AccountRow
-      v-for="a in store.items"
-      :key="a.id"
-      :initial="a"
-      readonly
-      @delete="store.remove(a.id)"
-      @edit="edit(a.id)"
-    />
-
-    <!-- Черновики (редактируемые строки) -->
     <AccountRow
       v-for="(d, i) in drafts"
       :key="d.id"
@@ -30,15 +19,29 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { NButton } from 'naive-ui'
 import AccountRow from './AccountRow.vue'
 import type { AccountDraft, Account } from '@/types/accounts'
 import { useAccountsStore } from '@/stores/accounts'
 
 const store = useAccountsStore()
-
 const drafts = ref<AccountDraft[]>([])
+
+onMounted(() => {
+  drafts.value = store.items.map((a) => ({
+    id: a.id,
+    labelsInput: (a.labels ?? [])
+      .map((t) => t.text)
+      .filter(Boolean)
+      .join('; '),
+    type: a.type,
+    login: a.login,
+    password: a.password ?? '',
+    errors: {},
+    touched: {},
+  }))
+})
 
 function add() {
   drafts.value.push({
@@ -54,26 +57,11 @@ function add() {
 
 function deleteDraft(id: string) {
   drafts.value = drafts.value.filter((d) => d.id !== id)
+  store.remove(id)
 }
 
 function saveDraft(a: Account) {
-  // валидная строка → убрать из черновиков и сохранить в стор
-  deleteDraft(a.id)
   store.upsert(a)
-}
-
-function edit(id: string) {
-  const a = store.items.find((x) => x.id === id)
-  if (!a) return
-  drafts.value.push({
-    id: a.id,
-    labelsInput: a.labels.map((t) => t.text).join('; '),
-    type: a.type,
-    login: a.login,
-    password: a.password ?? '',
-    errors: {},
-    touched: {},
-  })
 }
 </script>
 

--- a/src/components/accounts/AccountsForm.vue
+++ b/src/components/accounts/AccountsForm.vue
@@ -7,16 +7,6 @@
 
     <p class="hint">Для указания нескольких меток используйте разделитель «;»</p>
 
-    <!-- Черновики (редактируемые строки) -->
-    <AccountRow
-      v-for="(d, i) in drafts"
-      :key="d.id"
-      :model-value="d"
-      @update:model-value="(val) => (drafts[i] = val)"
-      @delete="deleteDraft(d.id)"
-      @submit-valid="saveDraft"
-    />
-
     <!-- Сохранённые элементы из стора (показываем как readonly) -->
     <AccountRow
       v-for="a in store.items"
@@ -25,6 +15,16 @@
       readonly
       @delete="store.remove(a.id)"
       @edit="edit(a.id)"
+    />
+
+    <!-- Черновики (редактируемые строки) -->
+    <AccountRow
+      v-for="(d, i) in drafts"
+      :key="d.id"
+      :model-value="d"
+      @update:model-value="(val) => (drafts[i] = val)"
+      @delete="deleteDraft(d.id)"
+      @submit-valid="saveDraft"
     />
   </div>
 </template>

--- a/src/components/accounts/AccountsForm.vue
+++ b/src/components/accounts/AccountsForm.vue
@@ -5,7 +5,17 @@
       <n-button type="primary" @click="add">+</n-button>
     </div>
 
-    <p class="hint">Для указания нескольких меток используйте разделитель «;»</p>
+    <n-alert type="info" :show-icon="true" class="hint">
+      Для указания нескольких меток для одной пары логин/пароль используйте разделитель «;»
+    </n-alert>
+
+    <div class="header">
+      <div class="hcell">Метки</div>
+      <div class="hcell">Тип записи</div>
+      <div class="hcell">Логин</div>
+      <div class="hcell">Пароль</div>
+      <div class="hcell"></div>
+    </div>
 
     <AccountRow
       v-for="(d, i) in drafts"
@@ -20,7 +30,7 @@
 
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
-import { NButton } from 'naive-ui'
+import { NButton, NAlert } from 'naive-ui'
 import AccountRow from './AccountRow.vue'
 import type { AccountDraft, Account } from '@/types/accounts'
 import { useAccountsStore } from '@/stores/accounts'
@@ -72,9 +82,24 @@ function saveDraft(a: Account) {
   gap: 12px;
   margin: 16px 0;
 }
+
 .hint {
   color: #6b7280;
   font-size: 12px;
   margin: 8px 0 16px;
+  padding: 2px 10px;
+}
+
+.header {
+  display: grid;
+  grid-template-columns: 1.2fr 0.9fr 1.6fr 1.2fr 40px;
+  gap: 12px;
+  align-items: end;
+  margin: 0 0 6px;
+}
+
+.hcell {
+  font-size: 12px;
+  color: #6b7280;
 }
 </style>

--- a/src/composables/useAccountValidation.spec.ts
+++ b/src/composables/useAccountValidation.spec.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest'
+import { validateDraft } from './useAccountValidation'
+import type { AccountDraft } from '@/types/accounts'
+const base = (): AccountDraft => ({
+  id: 'id1',
+  labelsInput: 'HR;IT',
+  type: 'Local',
+  login: 'alice',
+  password: 'secret',
+  errors: {},
+  touched: {},
+})
+
+describe('validateDraft', () => {
+  it('requires login and max 100', () => {
+    const d = base()
+    d.login = ''
+    const { errors, isValid } = validateDraft(d)
+    expect(isValid).toBe(false)
+    expect(errors.login).toBeTruthy()
+  })
+
+  it('Local requires password', () => {
+    const d = base()
+    d.password = ''
+    const { errors, isValid } = validateDraft(d)
+    expect(isValid).toBe(false)
+    expect(errors.password).toBeTruthy()
+  })
+
+  it('LDAP hides password (null in toAccount)', () => {
+    const d = base()
+    d.type = 'LDAP'
+    const { isValid, toAccount } = validateDraft(d)
+    expect(isValid).toBe(true)
+    expect(toAccount().password).toBeNull()
+  })
+
+  it('labels length limited to 50 chars', () => {
+    const d = base()
+    d.labelsInput = 'x'.repeat(51)
+    const { errors, isValid } = validateDraft(d)
+    expect(isValid).toBe(false)
+    expect(errors.labels).toBeTruthy()
+  })
+})

--- a/src/composables/useAccountValidation.ts
+++ b/src/composables/useAccountValidation.ts
@@ -16,6 +16,10 @@ export function validateDraft(d: AccountDraft) {
     else if (pwd.length > 100) errors.password = 'Макс. 100 символов'
   }
 
+  if (d.labelsInput && d.labelsInput.length > 50) {
+    errors.labels = 'Максимум 50 символов'
+  }
+
   const isValid = Object.keys(errors).length === 0
 
   const toAccount = (): Account => ({

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,13 @@
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 import App from './App.vue'
+import { useAccountsStore } from '@/stores/accounts'
 
 const app = createApp(App)
+const pinia = createPinia()
+app.use(pinia)
 
-app.use(createPinia())
+const store = useAccountsStore()
+store.load()
 
 app.mount('#app')

--- a/src/stores/accounts.spec.ts
+++ b/src/stores/accounts.spec.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useAccountsStore } from './accounts'
+
+const KEY = 'accounts:v1'
+
+describe('accounts store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+  })
+
+  it('upsert() writes to localStorage and load() restores', () => {
+    const store = useAccountsStore()
+    store.upsert({
+      id: 'a1',
+      labels: [{ text: 'HR' }],
+      type: 'Local',
+      login: 'alice',
+      password: 'pwd',
+    })
+    const raw = localStorage.getItem(KEY)!
+    expect(JSON.parse(raw)).toHaveLength(1)
+
+    const fresh = useAccountsStore()
+    fresh.load()
+    expect(fresh.items[0]).toMatchObject({
+      id: 'a1',
+      login: 'alice',
+      type: 'Local',
+      labels: [{ text: 'HR' }],
+      password: 'pwd',
+    })
+  })
+
+  it('load() normalizes legacy labels', () => {
+    localStorage.setItem(
+      KEY,
+      JSON.stringify([
+        { id: 'x', labels: 'HR;IT', type: 'LDAP', login: 'bob', password: 'ignored' },
+      ]),
+    )
+    const store = useAccountsStore()
+    store.load()
+    expect(store.items[0].labels).toEqual([{ text: 'HR' }, { text: 'IT' }])
+    expect(store.items[0].password).toBeNull()
+  })
+})

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,0 +1,35 @@
+import { beforeAll, afterAll, vi } from 'vitest'
+
+const store = new Map<string, string>()
+
+const MOCK_UUID =
+  '123e4567-e89b-12d3-a456-426614174000' as `${string}-${string}-${string}-${string}-${string}`
+
+const mockCrypto: Pick<Crypto, 'randomUUID'> = {
+  randomUUID: () => MOCK_UUID,
+}
+vi.stubGlobal('crypto', mockCrypto)
+
+beforeAll(() => {
+  const mockLocalStorage: Storage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => {
+      store.set(k, v)
+    },
+    removeItem: (k: string) => {
+      store.delete(k)
+    },
+    clear: () => {
+      store.clear()
+    },
+    key: (i: number) => Array.from(store.keys())[i] ?? null,
+    get length() {
+      return store.size
+    },
+  }
+  vi.stubGlobal('localStorage', mockLocalStorage)
+})
+
+afterAll(() => {
+  store.clear()
+})

--- a/src/utils/tags.spec.ts
+++ b/src/utils/tags.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { parseLabels } from './tags'
+
+describe('parseLabels', () => {
+  it('splits by ";" trims and removes empties', () => {
+    expect(parseLabels(' HR; Admin ; ; IT ')).toEqual([
+      { text: 'HR' },
+      { text: 'Admin' },
+      { text: 'IT' },
+    ])
+  })
+
+  it('returns empty for empty string', () => {
+    expect(parseLabels('')).toEqual([])
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from 'vitest/config'
+import vue from '@vitejs/plugin-vue'
+import { fileURLToPath, URL } from 'node:url'
+
+export default defineConfig({
+  plugins: [vue()],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+    },
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: 'src/tests/setup.ts',
+    css: true,
+    coverage: {
+      provider: 'v8',
+      reportsDirectory: './coverage',
+      reporter: ['text', 'html'],
+    },
+  },
+})


### PR DESCRIPTION
Добавлены unit-тесты Vitest:
  - utils: parseLabels — разбор меток по «;»
  - composables: validateDraft — валидация логина/пароля/меток и маппинг в Account
  - store: accounts — persist в localStorage, нормализация старого формата labels, LDAP → password=null
  - components: AccountRow/AccountsForm — валидация по blur/change, показ/скрытие пароля, переключение LDAP/Local