### PR TITLE
feat: константы + SRP-рефакторинг формы + нормализация стора + Docker prod-сборка

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,21 @@
+# syntax=docker/dockerfile:1.6
+
+# 1) deps 
+FROM node:20-alpine AS deps
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci --no-audit --no-fund
+
+# 2) build
 FROM node:20-alpine AS build
 WORKDIR /app
-
-COPY package*.json ./
-RUN npm ci
-
+COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN npm run build
 
+# 3) runtime
 FROM nginx:1.27-alpine AS runtime
 COPY nginx.conf /etc/nginx/conf.d/default.conf
 COPY --from=build /app/dist /usr/share/nginx/html
-
 EXPOSE 80
 CMD ["nginx", "-g", "daemon off;"]

--- a/README.md
+++ b/README.md
@@ -1,39 +1,56 @@
-# vue-accounts-from-test
+# Vue Accounts Form
 
-This template should help get you started developing with Vue 3 in Vite.
+Форма управления учётными записями (логин/пароль/метки), написанная на **Vue 3 + Pinia + Naive UI**.  
+Поддерживает локальное хранение данных и валидацию полей. Есть автотесты на **Vitest** и возможность сборки Docker-образа.
 
-## Recommended IDE Setup
+🌐 Демо: [vue-accounts-form-xi.vercel.app](https://vue-accounts-form-xi.vercel.app/)
 
-[VSCode](https://code.visualstudio.com/) + [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) (and disable Vetur).
+---
 
-## Type Support for `.vue` Imports in TS
+## 🚀 Запуск проекта локально
 
-TypeScript cannot handle type information for `.vue` imports by default, so we replace the `tsc` CLI with `vue-tsc` for type checking. In editors, we need [Volar](https://marketplace.visualstudio.com/items?itemName=Vue.volar) to make the TypeScript language service aware of `.vue` types.
+Убедитесь, что у вас установлен **Node.js 20+**.
 
-## Customize configuration
+```bash
+git clone https://github.com/ColdCactus528/vue-accounts-form.git
+cd vue-accounts-form
 
-See [Vite Configuration Reference](https://vite.dev/config/).
+# Установка зависимостей
+npm ci
 
-## Project Setup
-
-```sh
-npm install
-```
-
-### Compile and Hot-Reload for Development
-
-```sh
+# Запуск в режиме разработки
 npm run dev
-```
 
-### Type-Check, Compile and Minify for Production
+# Проверка типов
+npm run type-check
 
-```sh
+# Сборка production-версии
 npm run build
+
+# Локальный предпросмотр собранного приложения
+npm run preview
 ```
 
-### Lint with [ESLint](https://eslint.org/)
+🧪 Тесты
+Тесты написаны с помощью Vitest и @vue/test-utils.
 
-```sh
-npm run lint
+```
+# Запуск всех тестов
+npm run test
+
+# Watch-режим
+npm run test:watch
+
+# Отчёт по покрытию
+npm run test:coverage
+```
+
+🐳 Docker
+
+Проект можно собрать и запускать в контейнере. После этого приложение будет доступно по адресу:
+👉 http://localhost:8080
+
+```
+docker build -t vue-accounts-form .
+docker run -p 8080:80 vue-accounts-form
 ```

--- a/src/components/accounts/AccountRow.spec.ts
+++ b/src/components/accounts/AccountRow.spec.ts
@@ -2,6 +2,7 @@ import { mount, type VueWrapper } from '@vue/test-utils'
 import { describe, it, expect } from 'vitest'
 import AccountRow from './AccountRow.vue'
 import type { Account, AccountDraft } from '@/types/accounts'
+import { ACCOUNT_TYPE_LOCAL, ACCOUNT_TYPE_LDAP } from '@/constants/accounts'
 
 function mountRow(model?: AccountDraft) {
   return mount(AccountRow, {
@@ -9,7 +10,7 @@ function mountRow(model?: AccountDraft) {
       modelValue: model ?? {
         id: 'r1',
         labelsInput: 'HR',
-        type: 'Local',
+        type: ACCOUNT_TYPE_LOCAL,
         login: 'a',
         password: 'p',
         errors: {},
@@ -51,7 +52,7 @@ describe('AccountRow', () => {
     const w = mountRow()
     const current = w.props('modelValue') as AccountDraft
     await w.setProps({
-      modelValue: { ...current, type: 'LDAP', password: '' },
+      modelValue: { ...current, type: ACCOUNT_TYPE_LDAP, password: '' },
     })
     await w.vm.$nextTick()
     expect(w.find('input[type="password"]').exists()).toBe(false)

--- a/src/components/accounts/AccountRow.vue
+++ b/src/components/accounts/AccountRow.vue
@@ -4,7 +4,7 @@
       <template #trigger>
         <n-input
           v-model:value="draft.labelsInput"
-          placeholder="Метка (через ; )"
+          :placeholder="labelsPlaceholder"
           @blur="onBlur('labels')"
           :status="err('labels')"
           :title="errMsg('labels') || undefined"
@@ -14,14 +14,19 @@
       {{ errMsg('labels') }}
     </n-tooltip>
 
-    <n-select :options="typeOptions" v-model:value="draft.type" @update:value="onTypeChange" />
+    <n-select
+      :options="typeOptions"
+      v-model:value="draft.type"
+      :placeholder="typePlaceholder"
+      @update:value="onTypeChange"
+    />
 
     <n-tooltip :disabled="!errMsg('login')" trigger="hover" placement="top">
       <template #trigger>
         <n-input
           :class="loginClass"
           v-model:value="draft.login"
-          placeholder="Логин"
+          :placeholder="loginPlaceholder"
           @blur="onBlur('login')"
           :status="err('login')"
           :title="errMsg('login') || undefined"
@@ -37,7 +42,7 @@
           class="password"
           v-model:value="draft.password"
           :type="showPwd ? 'text' : 'password'"
-          placeholder="Пароль"
+          :placeholder="passwordPlaceholder"
           @blur="onBlur('password')"
           :status="err('password')"
           :title="errMsg('password') || undefined"
@@ -71,7 +76,14 @@
 import { computed, ref, watch } from 'vue'
 import { NInput, NSelect, NButton, NTooltip } from 'naive-ui'
 import type { Account, AccountDraft } from '@/types/accounts'
+import { UI_TEXT } from '@/constants/uiText'
 import { validateDraft } from '@/composables/useAccountValidation'
+import {
+  ACCOUNT_TYPE_OPTIONS,
+  ACCOUNT_TYPE_LDAP,
+  ACCOUNT_TYPE_LOCAL,
+  TAGS_DELIMITER,
+} from '@/constants/accounts'
 
 const props = defineProps<{
   modelValue?: AccountDraft
@@ -89,7 +101,7 @@ const emit = defineEmits<{
 const inner = ref<AccountDraft>({
   id: props.initial?.id ?? '',
   labelsInput: props.initial?.labels?.map((t) => t.text).join('; ') ?? '',
-  type: props.initial?.type ?? 'Local',
+  type: props.initial?.type ?? ACCOUNT_TYPE_LOCAL,
   login: props.initial?.login ?? '',
   password: props.initial?.password ?? '',
   errors: {},
@@ -112,12 +124,13 @@ const draft = computed<AccountDraft>({
   },
 })
 
-const typeOptions = [
-  { label: 'LDAP', value: 'LDAP' },
-  { label: 'Локальная', value: 'Local' },
-]
+const typeOptions = ACCOUNT_TYPE_OPTIONS
+const labelsPlaceholder = UI_TEXT.placeholders.labels(TAGS_DELIMITER)
+const loginPlaceholder = UI_TEXT.placeholders.login
+const passwordPlaceholder = UI_TEXT.placeholders.password
+const typePlaceholder = UI_TEXT.placeholders.type
 
-const showPassword = computed(() => draft.value.type === 'Local')
+const showPassword = computed(() => draft.value.type === ACCOUNT_TYPE_LOCAL)
 
 const showPwd = ref(false)
 
@@ -144,7 +157,7 @@ function onBlur(field: 'labels' | 'login' | 'password') {
 }
 
 function onTypeChange() {
-  if (draft.value.type === 'LDAP') draft.value.password = ''
+  if (draft.value.type === ACCOUNT_TYPE_LDAP) draft.value.password = ''
   draft.value.touched.type = true
   runValidation()
 }

--- a/src/components/accounts/AccountsForm.spec.ts
+++ b/src/components/accounts/AccountsForm.spec.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import AccountsForm from './AccountsForm.vue'
 import { useAccountsStore } from '@/stores/accounts'
+import { STORAGE_KEY_ACCOUNTS } from '@/constants/accounts'
 
 describe('AccountsForm', () => {
   beforeEach(() => {
@@ -32,6 +33,6 @@ describe('AccountsForm', () => {
 
     const store = useAccountsStore()
     expect(store.items.length).toBe(1)
-    expect(JSON.parse(localStorage.getItem('accounts:v1')!)).toHaveLength(1)
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEY_ACCOUNTS)!)).toHaveLength(1)
   })
 })

--- a/src/components/accounts/AccountsForm.vue
+++ b/src/components/accounts/AccountsForm.vue
@@ -34,35 +34,17 @@ import { NButton, NAlert } from 'naive-ui'
 import AccountRow from './AccountRow.vue'
 import type { AccountDraft, Account } from '@/types/accounts'
 import { useAccountsStore } from '@/stores/accounts'
+import { accountToDraft, emptyDraft } from '@/utils/accountMappers'
 
 const store = useAccountsStore()
 const drafts = ref<AccountDraft[]>([])
 
 onMounted(() => {
-  drafts.value = store.items.map((a) => ({
-    id: a.id,
-    labelsInput: (a.labels ?? [])
-      .map((t) => t.text)
-      .filter(Boolean)
-      .join('; '),
-    type: a.type,
-    login: a.login,
-    password: a.password ?? '',
-    errors: {},
-    touched: {},
-  }))
+  drafts.value = store.items.map(accountToDraft)
 })
 
 function add() {
-  drafts.value.push({
-    id: crypto.randomUUID(),
-    labelsInput: '',
-    type: 'Local',
-    login: '',
-    password: '',
-    errors: {},
-    touched: {},
-  })
+  drafts.value.push(emptyDraft())
 }
 
 function deleteDraft(id: string) {

--- a/src/constants/accounts.ts
+++ b/src/constants/accounts.ts
@@ -1,0 +1,21 @@
+// Ключи хранилища
+export const STORAGE_KEY_ACCOUNTS = 'accounts:v1' as const
+
+// Ограничения
+export const MAX_LOGIN_LEN = 100
+export const MAX_PASSWORD_LEN = 100
+export const MAX_LABEL_INPUT_LEN = 50 // лимит длины одной строки ввода меток
+export const MAX_TAGS = 50 // максимум тегов после парсинга
+
+// Типы учётных записей
+export const ACCOUNT_TYPE_LDAP = 'LDAP' as const
+export const ACCOUNT_TYPE_LOCAL = 'Local' as const
+
+// Разделитель меток
+export const TAGS_DELIMITER = ';' as const
+
+// Опции для селекта типа
+export const ACCOUNT_TYPE_OPTIONS: { label: string; value: string }[] = [
+  { label: 'LDAP', value: ACCOUNT_TYPE_LDAP },
+  { label: 'Локальная', value: ACCOUNT_TYPE_LOCAL },
+]

--- a/src/constants/uiText.ts
+++ b/src/constants/uiText.ts
@@ -1,0 +1,13 @@
+export const UI_TEXT = {
+  placeholders: {
+    labels: (d: string) => `Метка (через ${d} )`,
+    login: 'Логин',
+    password: 'Пароль',
+    type: 'Выберите тип',
+  },
+  titles: {
+    delete: 'Удалить',
+    show: 'Показать',
+    hide: 'Скрыть',
+  },
+} as const

--- a/src/stores/accounts.spec.ts
+++ b/src/stores/accounts.spec.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useAccountsStore } from './accounts'
+import { STORAGE_KEY_ACCOUNTS, ACCOUNT_TYPE_LOCAL, ACCOUNT_TYPE_LDAP } from '@/constants/accounts'
 
-const KEY = 'accounts:v1'
+const KEY = STORAGE_KEY_ACCOUNTS
 
 describe('accounts store', () => {
   beforeEach(() => {
@@ -15,7 +16,7 @@ describe('accounts store', () => {
     store.upsert({
       id: 'a1',
       labels: [{ text: 'HR' }],
-      type: 'Local',
+      type: ACCOUNT_TYPE_LOCAL,
       login: 'alice',
       password: 'pwd',
     })
@@ -27,7 +28,7 @@ describe('accounts store', () => {
     expect(fresh.items[0]).toMatchObject({
       id: 'a1',
       login: 'alice',
-      type: 'Local',
+      type: ACCOUNT_TYPE_LOCAL,
       labels: [{ text: 'HR' }],
       password: 'pwd',
     })
@@ -37,7 +38,7 @@ describe('accounts store', () => {
     localStorage.setItem(
       KEY,
       JSON.stringify([
-        { id: 'x', labels: 'HR;IT', type: 'LDAP', login: 'bob', password: 'ignored' },
+        { id: 'x', labels: 'HR;IT', type: ACCOUNT_TYPE_LDAP, login: 'bob', password: 'ignored' },
       ]),
     )
     const store = useAccountsStore()

--- a/src/stores/accounts.ts
+++ b/src/stores/accounts.ts
@@ -1,7 +1,39 @@
 import { defineStore } from 'pinia'
-import type { Account } from '@/types/accounts'
+import type { Account, Tag } from '@/types/accounts'
+import { STORAGE_KEY_ACCOUNTS, ACCOUNT_TYPE_LDAP, TAGS_DELIMITER } from '@/constants/accounts'
 
-const STORAGE_KEY = 'accounts:v1'
+function isTagLike(x: unknown): x is Tag {
+  return !!x && typeof x === 'object' && typeof (x as Record<string, unknown>).text === 'string'
+}
+
+function normalizeAccount(raw: unknown): Account {
+  const r = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {}
+
+  const type: Account['type'] = r['type'] === ACCOUNT_TYPE_LDAP ? 'LDAP' : 'Local'
+
+  // labels: string | Tag[] | неизвестно → Tag[]
+  const labelsRaw = r['labels']
+  let labels: Tag[] = []
+  if (Array.isArray(labelsRaw) && labelsRaw.every(isTagLike)) {
+    labels = (labelsRaw as Tag[]).map(({ text }) => ({ text }))
+  } else if (typeof labelsRaw === 'string') {
+    labels = labelsRaw
+      .split(TAGS_DELIMITER)
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map((text) => ({ text }))
+  }
+
+  const id = r['id'] == null ? crypto.randomUUID() : String(r['id'])
+  const login =
+    typeof r['login'] === 'string' ? r['login'] : r['login'] != null ? String(r['login']) : ''
+
+  // для LDAP пароль всегда null
+  const password =
+    type === ACCOUNT_TYPE_LDAP ? null : typeof r['password'] === 'string' ? r['password'] : ''
+
+  return { id, type, login, password, labels }
+}
 
 export const useAccountsStore = defineStore('accounts', {
   state: () => ({
@@ -9,16 +41,18 @@ export const useAccountsStore = defineStore('accounts', {
   }),
   actions: {
     load() {
-      const raw = localStorage.getItem(STORAGE_KEY)
+      const raw = localStorage.getItem(STORAGE_KEY_ACCOUNTS)
       if (!raw) return
       try {
-        this.items = JSON.parse(raw)
+        const parsed = JSON.parse(raw) as unknown
+        this.items = Array.isArray(parsed) ? parsed.map(normalizeAccount) : []
       } catch (e) {
         console.error('Failed to parse accounts from storage', e)
+        this.items = []
       }
     },
     save() {
-      localStorage.setItem(STORAGE_KEY, JSON.stringify(this.items))
+      localStorage.setItem(STORAGE_KEY_ACCOUNTS, JSON.stringify(this.items))
     },
     upsert(acc: Account) {
       const i = this.items.findIndex((a) => a.id === acc.id)

--- a/src/utils/accountMappers.ts
+++ b/src/utils/accountMappers.ts
@@ -1,0 +1,27 @@
+import type { Account, AccountDraft } from '@/types/accounts'
+import { labelsToInput } from '@/utils/tags'
+import { ACCOUNT_TYPE_LOCAL } from '@/constants/accounts'
+
+export function accountToDraft(a: Account): AccountDraft {
+  return {
+    id: a.id,
+    labelsInput: labelsToInput(a.labels ?? []),
+    type: a.type,
+    login: a.login,
+    password: a.password ?? '',
+    errors: {},
+    touched: {},
+  }
+}
+
+export function emptyDraft(): AccountDraft {
+  return {
+    id: crypto.randomUUID(),
+    labelsInput: '',
+    type: ACCOUNT_TYPE_LOCAL,
+    login: '',
+    password: '',
+    errors: {},
+    touched: {},
+  }
+}

--- a/src/utils/tags.ts
+++ b/src/utils/tags.ts
@@ -1,8 +1,9 @@
 import type { Tag } from '@/types/accounts'
+import { TAGS_DELIMITER } from '@/constants/accounts'
 
 export function parseLabels(input: string): Tag[] {
   return input
-    .split(';')
+    .split(TAGS_DELIMITER)
     .map((s) => s.trim())
     .filter(Boolean)
     .map((text) => ({ text }))


### PR DESCRIPTION
## Кратко
Привёл код к требованиям ТЗ:
- убраны «магические» литералы → вынесены в константы;
- форматирование данных вынесено из компонентов (SRP);
- store нормализует устаревшие записи при загрузке;
- обновлены тесты;
- добавлена prod-сборка через Docker + Nginx.

## Что сделано
- constants:
  - `src/constants/accounts.ts` — ключ стораджа, типы, лимиты, разделитель меток, опции селекта.
- SRP:
  - `src/utils/accountMappers.ts` — мапперы `accountToDraft()`, `emptyDraft()`.
  - `AccountsForm.vue` — форматирование убрано, используется `accountToDraft/emptyDraft`.
  - `AccountRow.vue` — литералы заменены константами, placeholder меток формируется из разделителя
- Store:
  - `stores/accounts.ts` — `load()` нормализует legacy-записи:
    - `labels: "HR;IT"` → `[{ text: 'HR' }, { text: 'IT' }]`;
    - для `LDAP` пароль приводится к `null`;
    - аккуратные приведения типов, без `any`.
- Тесты:
  - specs переведены на константы (`ACCOUNT_TYPE_*`, `STORAGE_KEY_ACCOUNTS`);
  - тест стора проходит на нормализованных данных.
- Docker:
  - multi-stage `Dockerfile` (Node build → Nginx runtime);

## Почему это нужно
- Константы дают единообразие и исключают расхождения.
- SRP упрощает тестирование и поддержку компонентов.
- Нормализация стора гарантирует совместимость со старыми данными.
- Docker делает воспроизводимую prod-сборку и развёртывание.

## Как проверить
1. Unit-тесты:
   - `npm run test:run` — все должны пройти.
2. Локально:
   - `npm run build` → `vite build` успешен.
3. Docker:
   - `docker build -t vue-accounts .`
   - `docker run --rm -p 8080:80 vue-accounts`
   - открыть http://localhost:8080, проверить:
     - добавление/удаление записи,
     - валидации,
     - скрытие пароля при LDAP,
     - сохранение в localStorage и восстановление после перезагрузки.